### PR TITLE
feat: add user alias management

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,58 @@ gac ou delete /TempOU --force
 
 **Note:** The OU must be empty (no users or sub-OUs) before it can be deleted.
 
+### User Alias Management
+
+Email aliases allow users to receive mail at multiple addresses that all deliver to the same mailbox. This is useful for department addresses, role-based addresses, or alternative names.
+
+#### List User Aliases
+
+```bash
+# List all aliases for a user
+gac alias list user@example.com
+
+# List aliases for a specific user
+gac alias list john.doe@example.com
+```
+
+The output shows:
+- The primary user email
+- All configured aliases
+- Total count of aliases
+
+#### Add User Alias
+
+```bash
+# Add a department alias
+gac alias add user@example.com support@example.com
+
+# Add an alternative name
+gac alias add john.doe@example.com jdoe@example.com
+
+# Add a role-based alias
+gac alias add admin@example.com administrator@example.com
+```
+
+**Requirements:**
+- The alias must be in a domain or alias domain managed by your organization
+- The alias cannot already be in use by another user or group
+- The user account must exist
+
+#### Remove User Alias
+
+```bash
+# Remove an alias with confirmation
+gac alias remove user@example.com old-alias@example.com
+
+# Remove an alias without confirmation
+gac alias remove user@example.com support@example.com --force
+```
+
+**Flags:**
+- `-f, --force` - Skip confirmation prompt
+
+**WARNING:** After removal, the alias address will no longer deliver mail to this user.
+
 ### Data Transfers
 
 Transfer document ownership from one user to another:
@@ -528,6 +580,14 @@ gac transfer --from olduser@example.com --to newuser@example.com
 | `gac ou create <ou-path>` | Create a new organizational unit |
 | `gac ou update <ou-path>` | Update an organizational unit |
 | `gac ou delete <ou-path>` | Delete an organizational unit |
+
+### Alias Commands
+
+| Command | Description |
+|---------|-------------|
+| `gac alias list <user-email>` | List aliases for a user |
+| `gac alias add <user-email> <alias-email>` | Add an alias to a user |
+| `gac alias remove <user-email> <alias-email>` | Remove an alias from a user |
 
 ### Transfer Commands
 

--- a/cmd/alias-add.go
+++ b/cmd/alias-add.go
@@ -1,0 +1,98 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	admin "google.golang.org/api/admin/directory/v1"
+)
+
+// aliasAddCmd represents the alias add command
+var aliasAddCmd = &cobra.Command{
+	Use:   "add <user-email> <alias-email>",
+	Short: "Add an alias to a user",
+	Long: `Add an email alias to a Google Workspace user.
+
+Usage
+-----
+
+$ gac alias add user@example.com support@example.com
+$ gac alias add jdoe@example.com john@example.com
+$ gac alias add admin@example.com administrator@example.com
+
+Description
+-----------
+
+Adds an email alias to a user account. The alias must be in the same domain
+or an alias domain of your Google Workspace organization.
+
+After adding an alias, email sent to the alias address will be delivered to
+the user's primary mailbox.
+
+Examples:
+  # Add a department alias
+  gac alias add user@example.com support@example.com
+
+  # Add an alternative name
+  gac alias add john.doe@example.com jdoe@example.com
+
+  # Add a role-based alias
+  gac alias add admin@example.com administrator@example.com
+
+Requirements:
+  - The alias must be in a domain or alias domain managed by your organization
+  - The alias cannot already be in use by another user or group
+  - The user account must exist
+`,
+	Args: cobra.ExactArgs(2),
+	RunE: aliasAddRunFunc,
+}
+
+func init() {
+	aliasCmd.AddCommand(aliasAddCmd)
+}
+
+func aliasAddRunFunc(cmd *cobra.Command, args []string) error {
+	client, err := newAdminClient()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+		return err
+	}
+
+	userEmail := args[0]
+	aliasEmail := args[1]
+
+	// Validate email formats
+	if err := ValidateEmail(userEmail); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: Invalid user email format: %v\n", err)
+		return err
+	}
+
+	if err := ValidateEmail(aliasEmail); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: Invalid alias email format: %v\n", err)
+		return err
+	}
+
+	// Create the alias
+	alias := &admin.Alias{
+		Alias: aliasEmail,
+	}
+
+	result, err := client.Users.Aliases.Insert(userEmail, alias).Do()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error adding alias: %v\n", err)
+		fmt.Fprintf(os.Stderr, "\nCommon reasons for failure:\n")
+		fmt.Fprintf(os.Stderr, "  - User does not exist\n")
+		fmt.Fprintf(os.Stderr, "  - Alias already exists for another user or group\n")
+		fmt.Fprintf(os.Stderr, "  - Alias domain is not managed by your organization\n")
+		fmt.Fprintf(os.Stderr, "  - Insufficient permissions\n")
+		return err
+	}
+
+	fmt.Printf("Successfully added alias:\n\n")
+	fmt.Printf("  User:  %s\n", userEmail)
+	fmt.Printf("  Alias: %s\n", result.Alias)
+
+	return nil
+}

--- a/cmd/alias-list.go
+++ b/cmd/alias-list.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// aliasListCmd represents the alias list command
+var aliasListCmd = &cobra.Command{
+	Use:   "list <user-email>",
+	Short: "List aliases for a user",
+	Long: `List all email aliases for a Google Workspace user.
+
+Usage
+-----
+
+$ gac alias list user@example.com
+$ gac alias list jdoe@example.com
+
+Description
+-----------
+
+Lists all email aliases associated with a user account. Each alias is an
+alternative email address that delivers to the same mailbox as the primary
+user email.
+
+Examples:
+  # List all aliases for a user
+  gac alias list user@example.com
+
+  # List aliases for a specific user
+  gac alias list john.doe@example.com
+
+The output shows:
+  - The primary user email
+  - All configured aliases
+  - Total count of aliases
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: aliasListRunFunc,
+}
+
+func init() {
+	aliasCmd.AddCommand(aliasListCmd)
+}
+
+func aliasListRunFunc(cmd *cobra.Command, args []string) error {
+	client, err := newAdminClient()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+		return err
+	}
+
+	userEmail := args[0]
+
+	// Validate email format
+	if err := ValidateEmail(userEmail); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: Invalid email format: %v\n", err)
+		return err
+	}
+
+	// List aliases for the user
+	result, err := client.Users.Aliases.List(userEmail).Do()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error listing aliases: %v\n", err)
+		fmt.Fprintf(os.Stderr, "\nCommon reasons for failure:\n")
+		fmt.Fprintf(os.Stderr, "  - User does not exist\n")
+		fmt.Fprintf(os.Stderr, "  - Insufficient permissions\n")
+		fmt.Fprintf(os.Stderr, "  - Invalid user email\n")
+		return err
+	}
+
+	// Display results
+	fmt.Printf("Aliases for %s:\n\n", userEmail)
+
+	if len(result.Aliases) == 0 {
+		fmt.Println("No aliases found.")
+		return nil
+	}
+
+	for i, aliasInterface := range result.Aliases {
+		// The Aliases field is []interface{}, so we need to type assert
+		if aliasMap, ok := aliasInterface.(map[string]interface{}); ok {
+			if aliasEmail, ok := aliasMap["alias"].(string); ok {
+				fmt.Printf("%d. %s\n", i+1, aliasEmail)
+			}
+		}
+	}
+
+	fmt.Printf("\nTotal: %d alias(es)\n", len(result.Aliases))
+
+	return nil
+}

--- a/cmd/alias-remove.go
+++ b/cmd/alias-remove.go
@@ -1,0 +1,114 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	aliasRemoveForce bool
+)
+
+// aliasRemoveCmd represents the alias remove command
+var aliasRemoveCmd = &cobra.Command{
+	Use:   "remove <user-email> <alias-email>",
+	Short: "Remove an alias from a user",
+	Long: `Remove an email alias from a Google Workspace user.
+
+Usage
+-----
+
+$ gac alias remove user@example.com old-alias@example.com
+$ gac alias remove jdoe@example.com john@example.com --force
+
+Description
+-----------
+
+Removes an email alias from a user account. After removal, email sent to
+the alias address will no longer be delivered to the user's mailbox.
+
+By default, the command will prompt for confirmation before removing the
+alias. Use --force to skip the confirmation prompt.
+
+Examples:
+  # Remove an alias with confirmation
+  gac alias remove user@example.com old-alias@example.com
+
+  # Remove an alias without confirmation
+  gac alias remove user@example.com support@example.com --force
+
+WARNING: After removal, the alias address will no longer deliver mail to
+this user. Make sure this is intentional before proceeding.
+`,
+	Args: cobra.ExactArgs(2),
+	RunE: aliasRemoveRunFunc,
+}
+
+func init() {
+	aliasCmd.AddCommand(aliasRemoveCmd)
+	aliasRemoveCmd.Flags().BoolVarP(&aliasRemoveForce, "force", "f", false, "skip confirmation prompt")
+}
+
+func aliasRemoveRunFunc(cmd *cobra.Command, args []string) error {
+	client, err := newAdminClient()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+		return err
+	}
+
+	userEmail := args[0]
+	aliasEmail := args[1]
+
+	// Validate email formats
+	if err := ValidateEmail(userEmail); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: Invalid user email format: %v\n", err)
+		return err
+	}
+
+	if err := ValidateEmail(aliasEmail); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: Invalid alias email format: %v\n", err)
+		return err
+	}
+
+	// Show warning and prompt for confirmation unless --force is used
+	if !aliasRemoveForce {
+		fmt.Printf("WARNING: You are about to remove alias:\n")
+		fmt.Printf("  User:  %s\n", userEmail)
+		fmt.Printf("  Alias: %s\n\n", aliasEmail)
+		fmt.Printf("After removal, email to this alias will no longer be delivered.\n\n")
+		fmt.Printf("Type 'yes' to confirm removal: ")
+
+		var confirmation string
+		_, err := fmt.Scanln(&confirmation)
+		if err != nil {
+			// If there's an error reading input (e.g., EOF), treat as cancellation
+			fmt.Fprintf(os.Stderr, "\nRemoval cancelled.\n")
+			return nil
+		}
+
+		if confirmation != "yes" {
+			fmt.Println("Removal cancelled.")
+			return nil
+		}
+	}
+
+	// Remove the alias
+	err = client.Users.Aliases.Delete(userEmail, aliasEmail).Do()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error removing alias: %v\n", err)
+		fmt.Fprintf(os.Stderr, "\nCommon reasons for failure:\n")
+		fmt.Fprintf(os.Stderr, "  - User does not exist\n")
+		fmt.Fprintf(os.Stderr, "  - Alias does not exist for this user\n")
+		fmt.Fprintf(os.Stderr, "  - Alias email is incorrect\n")
+		fmt.Fprintf(os.Stderr, "  - Insufficient permissions\n")
+		return err
+	}
+
+	fmt.Printf("Successfully removed alias:\n")
+	fmt.Printf("  User:  %s\n", userEmail)
+	fmt.Printf("  Alias: %s\n", aliasEmail)
+
+	return nil
+}

--- a/cmd/alias.go
+++ b/cmd/alias.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// aliasCmd represents the alias command
+var aliasCmd = &cobra.Command{
+	Use:   "alias",
+	Short: "User alias operations",
+	Long: `Manage email aliases for Google Workspace users.
+
+Email aliases allow users to receive mail at multiple addresses that all
+deliver to the same mailbox. This is useful for department addresses,
+role-based addresses, or alternative names.
+
+Available Commands:
+  list    - List aliases for a user
+  add     - Add an alias to a user
+  remove  - Remove an alias from a user
+
+Examples:
+  # List all aliases for a user
+  gac alias list user@example.com
+
+  # Add an alias to a user
+  gac alias add user@example.com support@example.com
+
+  # Remove an alias from a user
+  gac alias remove user@example.com old-alias@example.com
+
+For more information on a specific command, use:
+  gac alias [command] --help
+`,
+}
+
+func init() {
+	rootCmd.AddCommand(aliasCmd)
+}

--- a/cmd/alias_test.go
+++ b/cmd/alias_test.go
@@ -1,0 +1,111 @@
+package cmd
+
+import (
+	"testing"
+)
+
+// TestAliasCommandExists verifies that the alias command is registered
+func TestAliasCommandExists(t *testing.T) {
+	if aliasCmd == nil {
+		t.Fatal("alias command is nil")
+	}
+
+	if aliasCmd.Use != "alias" {
+		t.Errorf("Expected alias command Use to be 'alias', got '%s'", aliasCmd.Use)
+	}
+
+	if aliasCmd.Short == "" {
+		t.Error("alias command should have a Short description")
+	}
+
+	if aliasCmd.Long == "" {
+		t.Error("alias command should have a Long description")
+	}
+}
+
+// TestAliasSubcommands verifies all expected alias subcommands exist
+func TestAliasSubcommands(t *testing.T) {
+	expectedCommands := []string{"list", "add", "remove"}
+
+	commands := aliasCmd.Commands()
+	commandMap := make(map[string]bool)
+
+	for _, cmd := range commands {
+		commandMap[cmd.Name()] = true
+	}
+
+	for _, cmdName := range expectedCommands {
+		if !commandMap[cmdName] {
+			t.Errorf("Alias command missing subcommand: %s", cmdName)
+		}
+	}
+}
+
+// TestAliasListCommand verifies the alias list command structure
+func TestAliasListCommand(t *testing.T) {
+	if aliasListCmd == nil {
+		t.Fatal("alias list command is nil")
+	}
+
+	if aliasListCmd.Short == "" {
+		t.Error("alias list command should have a Short description")
+	}
+
+	if aliasListCmd.Long == "" {
+		t.Error("alias list command should have a Long description")
+	}
+
+	if aliasListCmd.RunE == nil {
+		t.Error("alias list command should have a RunE function")
+	}
+}
+
+// TestAliasAddCommand verifies the alias add command structure
+func TestAliasAddCommand(t *testing.T) {
+	if aliasAddCmd == nil {
+		t.Fatal("alias add command is nil")
+	}
+
+	if aliasAddCmd.Short == "" {
+		t.Error("alias add command should have a Short description")
+	}
+
+	if aliasAddCmd.Long == "" {
+		t.Error("alias add command should have a Long description")
+	}
+
+	if aliasAddCmd.RunE == nil {
+		t.Error("alias add command should have a RunE function")
+	}
+}
+
+// TestAliasRemoveCommand verifies the alias remove command structure
+func TestAliasRemoveCommand(t *testing.T) {
+	if aliasRemoveCmd == nil {
+		t.Fatal("alias remove command is nil")
+	}
+
+	if aliasRemoveCmd.Short == "" {
+		t.Error("alias remove command should have a Short description")
+	}
+
+	if aliasRemoveCmd.Long == "" {
+		t.Error("alias remove command should have a Long description")
+	}
+
+	if aliasRemoveCmd.RunE == nil {
+		t.Error("alias remove command should have a RunE function")
+	}
+}
+
+// TestAliasRemoveCommandHasFlags verifies the alias remove command has expected flags
+func TestAliasRemoveCommandHasFlags(t *testing.T) {
+	expectedFlags := []string{"force"}
+
+	for _, flagName := range expectedFlags {
+		flag := aliasRemoveCmd.Flags().Lookup(flagName)
+		if flag == nil {
+			t.Errorf("alias remove command missing flag: %s", flagName)
+		}
+	}
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -414,6 +414,74 @@ gac ou delete /Sales
 gac ou delete /Operations
 ```
 
+---
+
+### 8. User Alias Management
+
+**File**: [`alias-management.sh`](alias-management.sh)
+
+Demonstrate user alias management - adding, listing, and removing email aliases:
+
+```bash
+#!/bin/bash
+# User Alias Management Example
+
+set -euo pipefail
+
+# Configuration
+USER_EMAIL="user@example.com"
+ALIAS1="support@example.com"
+ALIAS2="help@example.com"
+ALIAS3="info@example.com"
+
+echo "Managing aliases for user..."
+
+# List current aliases
+gac alias list "$USER_EMAIL"
+
+# Add aliases
+echo "Adding aliases..."
+gac alias add "$USER_EMAIL" "$ALIAS1"
+gac alias add "$USER_EMAIL" "$ALIAS2"
+gac alias add "$USER_EMAIL" "$ALIAS3"
+
+# List aliases after adding
+gac alias list "$USER_EMAIL"
+
+# Remove an alias
+echo "Removing alias..."
+gac alias remove "$USER_EMAIL" "$ALIAS2" --force
+
+# List final aliases
+gac alias list "$USER_EMAIL"
+
+echo "✓ Alias management complete"
+```
+
+**Usage**:
+```bash
+# Set your user and alias emails
+export USER_EMAIL=user@example.com
+export ALIAS1=support@example.com
+export ALIAS2=help@example.com
+export ALIAS3=info@example.com
+
+./examples/alias-management.sh
+```
+
+**Cleanup**:
+```bash
+# Remove all demo aliases
+gac alias remove user@example.com support@example.com --force
+gac alias remove user@example.com info@example.com --force
+```
+
+**Common Use Cases**:
+- Department addresses (support@, sales@, info@)
+- Role-based addresses (admin@, webmaster@)
+- Alternative name formats (first.last@, firstlast@)
+- Legacy addresses when renaming users
+
 ## Best Practices
 
 ### Security

--- a/examples/alias-management.sh
+++ b/examples/alias-management.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+#
+# User Alias Management Example
+#
+# This script demonstrates how to manage email aliases for users,
+# including adding, listing, and removing aliases.
+#
+# Usage:
+#   ./alias-management.sh
+
+set -euo pipefail
+
+echo "========================================="
+echo "User Alias Management Example"
+echo "========================================="
+echo ""
+echo "This script demonstrates:"
+echo "  1. Adding email aliases to users"
+echo "  2. Listing user aliases"
+echo "  3. Removing aliases"
+echo ""
+
+read -p "Press ENTER to start the demo (or Ctrl+C to cancel)..."
+echo ""
+
+# Configuration - Update these with your actual values
+USER_EMAIL="${USER_EMAIL:-user@example.com}"
+ALIAS1="${ALIAS1:-support@example.com}"
+ALIAS2="${ALIAS2:-help@example.com}"
+ALIAS3="${ALIAS3:-info@example.com}"
+
+echo "Demo Configuration:"
+echo "  User: $USER_EMAIL"
+echo "  Aliases to add: $ALIAS1, $ALIAS2, $ALIAS3"
+echo ""
+
+read -p "Press ENTER to continue..."
+echo ""
+
+# Step 1: List current aliases
+echo "[1/5] Listing current aliases for user..."
+echo ""
+gac alias list "$USER_EMAIL" || echo "User has no aliases yet"
+echo ""
+
+# Step 2: Add aliases
+echo "[2/5] Adding aliases to user..."
+echo ""
+
+echo "Adding alias: $ALIAS1"
+gac alias add "$USER_EMAIL" "$ALIAS1"
+echo ""
+
+echo "Adding alias: $ALIAS2"
+gac alias add "$USER_EMAIL" "$ALIAS2"
+echo ""
+
+echo "Adding alias: $ALIAS3"
+gac alias add "$USER_EMAIL" "$ALIAS3"
+echo ""
+
+echo "✓ Aliases added"
+echo ""
+
+# Step 3: List aliases after adding
+echo "[3/5] Listing all aliases after adding..."
+echo ""
+gac alias list "$USER_EMAIL"
+echo ""
+
+# Step 4: Demonstrate removing an alias
+echo "[4/5] Removing one alias..."
+echo ""
+echo "Removing alias: $ALIAS2"
+gac alias remove "$USER_EMAIL" "$ALIAS2" --force
+echo "✓ Alias removed"
+echo ""
+
+# Step 5: List final aliases
+echo "[5/5] Final alias list..."
+echo ""
+gac alias list "$USER_EMAIL"
+echo ""
+
+# Cleanup instructions
+echo "========================================="
+echo "Cleanup Instructions"
+echo "========================================="
+echo ""
+echo "To remove the remaining demo aliases, run:"
+echo ""
+echo "gac alias remove $USER_EMAIL $ALIAS1 --force"
+echo "gac alias remove $USER_EMAIL $ALIAS3 --force"
+echo ""
+echo "========================================="
+echo "Demo Complete!"
+echo "========================================="
+echo ""
+echo "Key Takeaways:"
+echo "  - Aliases allow users to receive mail at multiple addresses"
+echo "  - Aliases must be in your organization's domains"
+echo "  - Each alias can only be assigned to one user or group"
+echo "  - Removing an alias stops mail delivery to that address"
+echo ""
+echo "Common Use Cases:"
+echo "  - Department addresses (support@, sales@, info@)"
+echo "  - Role-based addresses (admin@, webmaster@)"
+echo "  - Alternative name formats (first.last@, firstlast@)"
+echo "  - Legacy addresses when renaming users"
+echo ""
+echo "For more information:"
+echo "  gac alias --help"
+echo "  gac alias <command> --help"


### PR DESCRIPTION
Implement comprehensive user alias management functionality:
- List aliases for a user
- Add new aliases to a user
- Remove aliases from a user

Implementation details:
- cmd/alias.go: Root command for alias operations
- cmd/alias-list.go: List user aliases
- cmd/alias-add.go: Add alias with validation
- cmd/alias-remove.go: Remove alias with confirmation prompt
- cmd/alias_test.go: Comprehensive test suite
- examples/alias-management.sh: Demo script
- README.md: Added alias management documentation
- examples/README.md: Added alias example section

Features:
- Email validation for user and alias addresses
- Confirmation prompt for alias removal (--force to skip)
- Detailed error messages with common failure reasons
- Type assertion handling for Google API []interface{} response

All tests passing (146 tests)
Linter: 0 issues
Gosec: 0 issues