### PR TITLE
feat: add group settings management (group-settings command)

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,75 @@ gac group list --contains-former-employees
 - `-m, --get-members` - List group members
 - `-i, --contains-former-employees` - Show only groups with inactive members
 
+### Group Settings Management
+
+#### View Group Settings
+
+```bash
+# View group settings in table format
+gac group-settings list operations@example.com
+
+# View group settings as JSON
+gac group-settings list engineering --format json
+```
+
+**Flags:**
+- `-f, --format` - Output format: table or json (default: table)
+
+#### Update Group Settings
+
+```bash
+# Allow anyone in domain to join
+gac group-settings update operations@example.com \
+  --who-can-join ALL_IN_DOMAIN_CAN_JOIN
+
+# Configure posting permissions
+gac group-settings update engineering@example.com \
+  --who-can-post-message ALL_MEMBERS_CAN_POST \
+  --allow-web-posting true
+
+# Disable external members
+gac group-settings update sales@example.com \
+  --allow-external-members false
+
+# Add custom footer to group emails
+gac group-settings update support@example.com \
+  --custom-footer-text "For assistance, contact support@example.com" \
+  --include-custom-footer true
+
+# Enable message moderation
+gac group-settings update announcements@example.com \
+  --message-moderation-level MODERATE_ALL_MESSAGES \
+  --who-can-moderate-content ALL_MANAGERS_CAN_POST
+
+# Configure reply-to settings
+gac group-settings update team@example.com \
+  --reply-to REPLY_TO_SENDER
+
+# Make group archive-only (read-only)
+gac group-settings update archive@example.com \
+  --archive-only true
+```
+
+**Common Access Control Values:**
+- `whoCanJoin`: CAN_REQUEST_TO_JOIN, ALL_IN_DOMAIN_CAN_JOIN, ANYONE_CAN_JOIN, INVITED_CAN_JOIN
+- `whoCanViewGroup`: ANYONE_CAN_VIEW, ALL_IN_DOMAIN_CAN_VIEW, ALL_MEMBERS_CAN_VIEW, ALL_MANAGERS_CAN_VIEW
+- `whoCanPostMessage`: NONE_CAN_POST, ALL_MANAGERS_CAN_POST, ALL_MEMBERS_CAN_POST, ALL_IN_DOMAIN_CAN_POST, ANYONE_CAN_POST
+
+**Common Moderation Values:**
+- `messageModerationLevel`: MODERATE_ALL_MESSAGES, MODERATE_NON_MEMBERS, MODERATE_NEW_MEMBERS, MODERATE_NONE
+
+**Common Reply-To Values:**
+- `replyTo`: REPLY_TO_CUSTOM, REPLY_TO_SENDER, REPLY_TO_LIST, REPLY_TO_OWNER, REPLY_TO_IGNORE
+
+**Common use cases:**
+- Restricting group access to internal members only
+- Configuring who can post messages to prevent spam
+- Setting up moderated groups for announcements
+- Adding custom footers for compliance or branding
+- Creating read-only archive groups for historical records
+- Controlling member invitation and approval workflows
+
 ### Calendar Operations
 
 #### Create Calendar Event
@@ -726,6 +795,13 @@ gac transfer --from olduser@example.com --to newuser@example.com
 | Command | Description |
 |---------|-------------|
 | `gac group list [email]` | List groups or get details for specific group |
+
+### Group Settings Commands
+
+| Command | Description |
+|---------|-------------|
+| `gac group-settings list <group-email>` | View group settings |
+| `gac group-settings update <group-email>` | Update group settings |
 
 ### Calendar Commands
 

--- a/TODO.md
+++ b/TODO.md
@@ -390,10 +390,10 @@ Implementation details:
 - [x] Add organizational unit management
 - [x] Add alias management for users
 - [x] Add calendar resource management
-- [ ] Add group settings management
+- [x] Add group settings management
 - [ ] Add audit log export
 
-**Status:** 🚧 In Progress (4/6 features complete)
+**Status:** 🚧 In Progress (5/6 features complete)
 
 **Organizational Unit Management** - ✅ Complete
 Implementation details:
@@ -557,6 +557,58 @@ Implementation details:
   - Phone/audio equipment
   - Display screens
   - Custom feature tags
+
+**Group Settings Management** - ✅ Complete
+Implementation details:
+- **`gac group-settings list`**: View group settings
+  - Supports `--format` flag (table/json) for output format
+  - Displays all group configuration settings
+  - Shows access control, posting, email, archive, and moderation settings
+  - Table format for human reading, JSON for scripting
+- **`gac group-settings update`**: Update group settings
+  - Comprehensive flag support for all group settings
+  - Access control: who-can-join, who-can-view-group, allow-external-members
+  - Posting permissions: who-can-post-message, allow-web-posting, message-moderation-level
+  - Email settings: reply-to, custom-reply-to, custom-footer-text, include-custom-footer
+  - Archive settings: archive-only, show-in-group-directory
+  - Member management: who-can-add, who-can-invite, who-can-approve-members
+  - Moderation: who-can-moderate-members, who-can-moderate-content, who-can-ban-users
+  - Supports partial updates (only specified fields changed)
+  - Uses ForceSendFields to ensure boolean values are sent correctly
+- **Tests**: Added comprehensive test suite in `cmd/group-settings_test.go`
+  - Tests for command existence and structure
+  - Validates all 26+ flags are present in update command
+  - Tests command registration with root
+  - All tests passing
+- **Documentation**:
+  - README.md updated with group settings management section
+  - Detailed examples for common configuration scenarios
+  - List of all available settings and their values
+  - examples/group-settings-management.sh demo script
+  - examples/README.md updated with Section 11
+- **OAuth Scopes Added**:
+  - Added `groupssettings.AppsGroupsSettingsScope` to client.go
+  - Created `newGroupsSettingsClient()` function
+- **Files Created**:
+  - `cmd/group-settings.go` - Root group-settings command
+  - `cmd/group-settings-list.go` - View group settings
+  - `cmd/group-settings-update.go` - Update group settings
+  - `cmd/group-settings_test.go` - Test suite
+  - `examples/group-settings-management.sh` - Demo script
+- **Common Use Cases**:
+  - Restricting group access to internal members only
+  - Configuring posting permissions to prevent spam
+  - Setting up moderated announcement groups
+  - Adding custom footers for compliance/branding
+  - Creating read-only archive groups
+  - Managing external partner collaboration groups
+- **Key Features**:
+  - 26+ configurable settings covering all aspects of group behavior
+  - Support for access control (join, view, membership)
+  - Posting and moderation controls
+  - Email customization (footers, reply-to)
+  - Archive and directory visibility
+  - Member invitation and approval workflows
 
 </details>
 

--- a/TODO.md
+++ b/TODO.md
@@ -623,7 +623,7 @@ Implementation details:
 
 **Status:** ✅ Complete
 - **Makefile**: Comprehensive build automation with targets for build, test, lint, fmt, clean, docker-build, etc.
-- **Pre-commit hooks**: Both `.pre-commit-config.yaml` for pre-commit framework and `.git/hooks/pre-commit` script that runs fmt, vet, tidy, and build
+- **Pre-commit hooks**: Both `.pre-commit-config.yaml` for pre-commit framework and `.git/hooks/pre-commit` script that runs fmt, vet, lint, tidy, and build
 - **Devcontainer**: VS Code devcontainer configuration with Go 1.25, extensions, and credential mounting
 - **DEBUGGING.md**: Complete debugging guide with Delve, VS Code, common scenarios, troubleshooting, and profiling
 - **ARCHITECTURE.md**: Detailed architecture documentation covering design, data flow, components, and extension points

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -19,6 +19,7 @@ import (
 	datatransfer "google.golang.org/api/admin/datatransfer/v1"
 	admin "google.golang.org/api/admin/directory/v1"
 	calendar "google.golang.org/api/calendar/v3"
+	groupssettings "google.golang.org/api/groupssettings/v1"
 	"google.golang.org/api/option"
 )
 
@@ -39,6 +40,7 @@ var (
 		calendar.CalendarEventsScope,
 		calendar.CalendarEventsReadonlyScope,
 		datatransfer.AdminDatatransferScope,
+		groupssettings.AppsGroupsSettingsScope,
 	}
 )
 
@@ -148,6 +150,20 @@ func newDataTransferClient() (*datatransfer.Service, error) {
 	}
 
 	srv, err := datatransfer.NewService(context.Background(), option.WithHTTPClient(client))
+	if err != nil {
+		return nil, err
+	}
+
+	return srv, nil
+}
+
+func newGroupsSettingsClient() (*groupssettings.Service, error) {
+	client, err := newHTTPClient()
+	if err != nil {
+		return nil, err
+	}
+
+	srv, err := groupssettings.NewService(context.Background(), option.WithHTTPClient(client))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/group-settings-list.go
+++ b/cmd/group-settings-list.go
@@ -99,7 +99,10 @@ func displayGroupSettings(settings interface{}) {
 	if !ok {
 		// If not a map, try to marshal and unmarshal to get a map
 		bytes, _ := json.Marshal(settings)
-		json.Unmarshal(bytes, &settingsMap)
+		if err := json.Unmarshal(bytes, &settingsMap); err != nil {
+			fmt.Fprintf(os.Stderr, "Error converting settings to map: %v\n", err)
+			return
+		}
 	}
 
 	fmt.Printf("Group Settings\n")

--- a/cmd/group-settings-list.go
+++ b/cmd/group-settings-list.go
@@ -1,0 +1,201 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	groupSettingsListFormat string
+)
+
+// groupSettingsListCmd represents the group-settings list command
+var groupSettingsListCmd = &cobra.Command{
+	Use:   "list [group-email]",
+	Short: "View group settings",
+	Long: `View settings for a Google Workspace group.
+
+Usage
+-----
+
+$ gac group-settings list operations@example.com
+$ gac group-settings list engineering
+$ gac group-settings list sales@example.com --format json
+
+Description
+-----------
+
+Displays the settings for a group, including:
+- Who can join the group
+- Who can view group messages
+- Who can post messages
+- Message moderation settings
+- Email delivery preferences
+- Archive settings
+- Custom footer text
+
+The --format flag controls output format:
+  table - Human-readable table format (default)
+  json  - JSON format for scripting
+
+If you don't include the @domain part in the group email, the configured domain
+will be automatically appended.
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: groupSettingsListRunFunc,
+}
+
+func init() {
+	groupSettingsCmd.AddCommand(groupSettingsListCmd)
+	groupSettingsListCmd.Flags().StringVarP(&groupSettingsListFormat, "format", "f", "table", "output format: table or json")
+}
+
+func groupSettingsListRunFunc(cmd *cobra.Command, args []string) error {
+	groupEmail := args[0]
+	if !strings.Contains(groupEmail, "@") {
+		groupEmail = groupEmail + "@" + getDomain()
+	}
+
+	// Validate email
+	if err := ValidateEmail(groupEmail); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: Invalid group email: %v\n", err)
+		return err
+	}
+
+	client, err := newGroupsSettingsClient()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+		return err
+	}
+
+	settings, err := client.Groups.Get(groupEmail).Do()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error getting group settings for %s: %v\n", groupEmail, err)
+		return err
+	}
+
+	if groupSettingsListFormat == "json" {
+		buf, err := json.MarshalIndent(settings, "", "  ")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting JSON: %v\n", err)
+			return err
+		}
+		fmt.Printf("%s\n", buf)
+	} else {
+		// Table format
+		displayGroupSettings(settings)
+	}
+
+	return nil
+}
+
+func displayGroupSettings(settings interface{}) {
+	// Type assert to map for flexible access
+	settingsMap, ok := settings.(map[string]interface{})
+	if !ok {
+		// If not a map, try to marshal and unmarshal to get a map
+		bytes, _ := json.Marshal(settings)
+		json.Unmarshal(bytes, &settingsMap)
+	}
+
+	fmt.Printf("Group Settings\n")
+	fmt.Printf("==============\n\n")
+
+	// Basic Information
+	printSetting("Email", settingsMap["email"])
+	printSetting("Name", settingsMap["name"])
+	printSetting("Description", settingsMap["description"])
+	fmt.Println()
+
+	// Access Settings
+	fmt.Printf("Access Settings:\n")
+	fmt.Printf("----------------\n")
+	printSetting("  Who Can Join", settingsMap["whoCanJoin"])
+	printSetting("  Who Can View Group", settingsMap["whoCanViewGroup"])
+	printSetting("  Who Can View Membership", settingsMap["whoCanViewMembership"])
+	printSetting("  Allow External Members", settingsMap["allowExternalMembers"])
+	fmt.Println()
+
+	// Posting Settings
+	fmt.Printf("Posting Settings:\n")
+	fmt.Printf("-----------------\n")
+	printSetting("  Who Can Post Message", settingsMap["whoCanPostMessage"])
+	printSetting("  Allow Web Posting", settingsMap["allowWebPosting"])
+	printSetting("  Message Moderation Level", settingsMap["messageModerationLevel"])
+	printSetting("  Spam Moderation Level", settingsMap["spamModerationLevel"])
+	fmt.Println()
+
+	// Email Settings
+	fmt.Printf("Email Settings:\n")
+	fmt.Printf("---------------\n")
+	printSetting("  Send Message Deny Notification", settingsMap["sendMessageDenyNotification"])
+	printSetting("  Reply To", settingsMap["replyTo"])
+	printSetting("  Custom Reply To", settingsMap["customReplyTo"])
+	printSetting("  Include Custom Footer", settingsMap["includeCustomFooter"])
+	if customFooter, ok := settingsMap["customFooterText"].(string); ok && customFooter != "" {
+		printSetting("  Custom Footer Text", customFooter)
+	}
+	printSetting("  Include in Global Address List", settingsMap["includeInGlobalAddressList"])
+	fmt.Println()
+
+	// Moderation Settings
+	fmt.Printf("Moderation Settings:\n")
+	fmt.Printf("--------------------\n")
+	printSetting("  Who Can Contact Owner", settingsMap["whoCanContactOwner"])
+	printSetting("  Who Can Moderate Members", settingsMap["whoCanModerateMembers"])
+	printSetting("  Who Can Moderate Content", settingsMap["whoCanModerateContent"])
+	fmt.Println()
+
+	// Archive Settings
+	fmt.Printf("Archive Settings:\n")
+	fmt.Printf("-----------------\n")
+	printSetting("  Archive Only", settingsMap["archiveOnly"])
+	printSetting("  Message Display Font", settingsMap["messageDisplayFont"])
+	printSetting("  Show in Group Directory", settingsMap["showInGroupDirectory"])
+	printSetting("  Max Message Bytes", settingsMap["maxMessageBytes"])
+	printSetting("  Is Archived", settingsMap["isArchived"])
+	fmt.Println()
+
+	// Member Settings
+	fmt.Printf("Member Settings:\n")
+	fmt.Printf("----------------\n")
+	printSetting("  Who Can Leave Group", settingsMap["whoCanLeaveGroup"])
+	printSetting("  Who Can Add", settingsMap["whoCanAdd"])
+	printSetting("  Who Can Invite", settingsMap["whoCanInvite"])
+	printSetting("  Who Can Approve Members", settingsMap["whoCanApproveMembers"])
+	printSetting("  Who Can Ban Users", settingsMap["whoCanBanUsers"])
+	printSetting("  Allow Google Communication", settingsMap["allowGoogleCommunication"])
+	printSetting("  Members Can Post As The Group", settingsMap["membersCanPostAsTheGroup"])
+	fmt.Println()
+}
+
+func printSetting(label string, value interface{}) {
+	if value == nil {
+		return
+	}
+
+	// Convert value to string
+	var strValue string
+	switch v := value.(type) {
+	case string:
+		strValue = v
+	case bool:
+		if v {
+			strValue = "true"
+		} else {
+			strValue = "false"
+		}
+	case float64, int, int64:
+		strValue = fmt.Sprintf("%v", v)
+	default:
+		strValue = fmt.Sprintf("%v", v)
+	}
+
+	if strValue != "" && strValue != "0" {
+		fmt.Printf("%-35s: %s\n", label, strValue)
+	}
+}

--- a/cmd/group-settings-update.go
+++ b/cmd/group-settings-update.go
@@ -1,0 +1,341 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	groupssettings "google.golang.org/api/groupssettings/v1"
+)
+
+var (
+	whoCanJoin                  string
+	whoCanViewGroup             string
+	whoCanViewMembership        string
+	whoCanPostMessage           string
+	whoCanContactOwner          string
+	allowExternalMembers        string
+	allowWebPosting             string
+	archiveOnly                 string
+	messageModerationLevel      string
+	spamModerationLevel         string
+	replyTo                     string
+	customReplyTo               string
+	includeCustomFooter         string
+	customFooterText            string
+	sendMessageDenyNotification string
+	includeInGlobalAddressList  string
+	showInGroupDirectory        string
+	allowGoogleCommunication    string
+	membersCanPostAsTheGroup    string
+	whoCanLeaveGroup            string
+	whoCanAdd                   string
+	whoCanInvite                string
+	whoCanApproveMembers        string
+	whoCanModerateMembers       string
+	whoCanModerateContent       string
+	whoCanBanUsers              string
+)
+
+// groupSettingsUpdateCmd represents the group-settings update command
+var groupSettingsUpdateCmd = &cobra.Command{
+	Use:   "update [group-email]",
+	Short: "Update group settings",
+	Long: `Update settings for a Google Workspace group.
+
+Usage
+-----
+
+$ gac group-settings update operations@example.com --who-can-join ALL_IN_DOMAIN_CAN_JOIN
+$ gac group-settings update engineering --allow-external-members false
+$ gac group-settings update sales@example.com --who-can-post-message ALL_MEMBERS_CAN_POST
+$ gac group-settings update support@example.com --custom-footer-text "For help, contact support@example.com"
+
+Description
+-----------
+
+Updates group settings. You can specify one or more flags to update specific settings.
+Only the settings you specify will be updated; other settings will remain unchanged.
+
+Common Settings:
+
+Access Control:
+  --who-can-join              Who can join the group
+                              Values: CAN_REQUEST_TO_JOIN, ALL_IN_DOMAIN_CAN_JOIN,
+                                      ANYONE_CAN_JOIN, INVITED_CAN_JOIN
+  --who-can-view-group        Who can view group messages
+                              Values: ANYONE_CAN_VIEW, ALL_IN_DOMAIN_CAN_VIEW,
+                                      ALL_MEMBERS_CAN_VIEW, ALL_MANAGERS_CAN_VIEW
+  --who-can-view-membership   Who can view the member list
+  --allow-external-members    Allow external members (true/false)
+
+Posting Permissions:
+  --who-can-post-message      Who can post messages
+                              Values: NONE_CAN_POST, ALL_MANAGERS_CAN_POST,
+                                      ALL_MEMBERS_CAN_POST, ALL_IN_DOMAIN_CAN_POST,
+                                      ANYONE_CAN_POST
+  --allow-web-posting         Allow posting from web (true/false)
+  --message-moderation-level  Message moderation level
+                              Values: MODERATE_ALL_MESSAGES, MODERATE_NON_MEMBERS,
+                                      MODERATE_NEW_MEMBERS, MODERATE_NONE
+
+Email Settings:
+  --reply-to                  Reply-to setting
+                              Values: REPLY_TO_CUSTOM, REPLY_TO_SENDER,
+                                      REPLY_TO_LIST, REPLY_TO_OWNER, REPLY_TO_IGNORE
+  --custom-reply-to           Custom reply-to email address
+  --custom-footer-text        Custom footer text for messages
+  --include-custom-footer     Include custom footer (true/false)
+
+Archive Settings:
+  --archive-only              Make group archive-only (true/false)
+  --show-in-group-directory   Show in group directory (true/false)
+
+If you don't include the @domain part in the group email, the configured domain
+will be automatically appended.
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: groupSettingsUpdateRunFunc,
+}
+
+func init() {
+	groupSettingsCmd.AddCommand(groupSettingsUpdateCmd)
+
+	// Access control flags
+	groupSettingsUpdateCmd.Flags().StringVar(&whoCanJoin, "who-can-join", "", "who can join the group")
+	groupSettingsUpdateCmd.Flags().StringVar(&whoCanViewGroup, "who-can-view-group", "", "who can view group messages")
+	groupSettingsUpdateCmd.Flags().StringVar(&whoCanViewMembership, "who-can-view-membership", "", "who can view membership")
+	groupSettingsUpdateCmd.Flags().StringVar(&allowExternalMembers, "allow-external-members", "", "allow external members (true/false)")
+
+	// Posting permission flags
+	groupSettingsUpdateCmd.Flags().StringVar(&whoCanPostMessage, "who-can-post-message", "", "who can post messages")
+	groupSettingsUpdateCmd.Flags().StringVar(&allowWebPosting, "allow-web-posting", "", "allow web posting (true/false)")
+	groupSettingsUpdateCmd.Flags().StringVar(&messageModerationLevel, "message-moderation-level", "", "message moderation level")
+	groupSettingsUpdateCmd.Flags().StringVar(&spamModerationLevel, "spam-moderation-level", "", "spam moderation level")
+
+	// Email settings flags
+	groupSettingsUpdateCmd.Flags().StringVar(&replyTo, "reply-to", "", "reply-to setting")
+	groupSettingsUpdateCmd.Flags().StringVar(&customReplyTo, "custom-reply-to", "", "custom reply-to email")
+	groupSettingsUpdateCmd.Flags().StringVar(&customFooterText, "custom-footer-text", "", "custom footer text")
+	groupSettingsUpdateCmd.Flags().StringVar(&includeCustomFooter, "include-custom-footer", "", "include custom footer (true/false)")
+	groupSettingsUpdateCmd.Flags().StringVar(&sendMessageDenyNotification, "send-message-deny-notification", "", "send message deny notification (true/false)")
+	groupSettingsUpdateCmd.Flags().StringVar(&includeInGlobalAddressList, "include-in-global-address-list", "", "include in global address list (true/false)")
+
+	// Archive settings flags
+	groupSettingsUpdateCmd.Flags().StringVar(&archiveOnly, "archive-only", "", "archive only (true/false)")
+	groupSettingsUpdateCmd.Flags().StringVar(&showInGroupDirectory, "show-in-group-directory", "", "show in group directory (true/false)")
+
+	// Member management flags
+	groupSettingsUpdateCmd.Flags().StringVar(&whoCanLeaveGroup, "who-can-leave-group", "", "who can leave the group")
+	groupSettingsUpdateCmd.Flags().StringVar(&whoCanAdd, "who-can-add", "", "who can add members")
+	groupSettingsUpdateCmd.Flags().StringVar(&whoCanInvite, "who-can-invite", "", "who can invite members")
+	groupSettingsUpdateCmd.Flags().StringVar(&whoCanApproveMembers, "who-can-approve-members", "", "who can approve members")
+	groupSettingsUpdateCmd.Flags().StringVar(&allowGoogleCommunication, "allow-google-communication", "", "allow Google communication (true/false)")
+	groupSettingsUpdateCmd.Flags().StringVar(&membersCanPostAsTheGroup, "members-can-post-as-the-group", "", "members can post as the group (true/false)")
+
+	// Moderation flags
+	groupSettingsUpdateCmd.Flags().StringVar(&whoCanContactOwner, "who-can-contact-owner", "", "who can contact owner")
+	groupSettingsUpdateCmd.Flags().StringVar(&whoCanModerateMembers, "who-can-moderate-members", "", "who can moderate members")
+	groupSettingsUpdateCmd.Flags().StringVar(&whoCanModerateContent, "who-can-moderate-content", "", "who can moderate content")
+	groupSettingsUpdateCmd.Flags().StringVar(&whoCanBanUsers, "who-can-ban-users", "", "who can ban users")
+}
+
+func groupSettingsUpdateRunFunc(cmd *cobra.Command, args []string) error {
+	groupEmail := args[0]
+	if !strings.Contains(groupEmail, "@") {
+		groupEmail = groupEmail + "@" + getDomain()
+	}
+
+	// Validate email
+	if err := ValidateEmail(groupEmail); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: Invalid group email: %v\n", err)
+		return err
+	}
+
+	// Validate custom reply-to email if provided
+	if customReplyTo != "" {
+		if err := ValidateEmail(customReplyTo); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: Invalid custom reply-to email: %v\n", err)
+			return err
+		}
+	}
+
+	client, err := newGroupsSettingsClient()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+		return err
+	}
+
+	// Build the update object with only the fields that were specified
+	groups := &groupssettings.Groups{
+		ForceSendFields: []string{}, // Track which fields to send
+	}
+
+	// Track if any settings were provided
+	hasUpdates := false
+
+	// Access control settings
+	if cmd.Flags().Changed("who-can-join") {
+		groups.WhoCanJoin = whoCanJoin
+		groups.ForceSendFields = append(groups.ForceSendFields, "WhoCanJoin")
+		hasUpdates = true
+	}
+	if cmd.Flags().Changed("who-can-view-group") {
+		groups.WhoCanViewGroup = whoCanViewGroup
+		groups.ForceSendFields = append(groups.ForceSendFields, "WhoCanViewGroup")
+		hasUpdates = true
+	}
+	if cmd.Flags().Changed("who-can-view-membership") {
+		groups.WhoCanViewMembership = whoCanViewMembership
+		groups.ForceSendFields = append(groups.ForceSendFields, "WhoCanViewMembership")
+		hasUpdates = true
+	}
+	if cmd.Flags().Changed("allow-external-members") {
+		groups.AllowExternalMembers = allowExternalMembers
+		groups.ForceSendFields = append(groups.ForceSendFields, "AllowExternalMembers")
+		hasUpdates = true
+	}
+
+	// Posting permission settings
+	if cmd.Flags().Changed("who-can-post-message") {
+		groups.WhoCanPostMessage = whoCanPostMessage
+		groups.ForceSendFields = append(groups.ForceSendFields, "WhoCanPostMessage")
+		hasUpdates = true
+	}
+	if cmd.Flags().Changed("allow-web-posting") {
+		groups.AllowWebPosting = allowWebPosting
+		groups.ForceSendFields = append(groups.ForceSendFields, "AllowWebPosting")
+		hasUpdates = true
+	}
+	if cmd.Flags().Changed("message-moderation-level") {
+		groups.MessageModerationLevel = messageModerationLevel
+		groups.ForceSendFields = append(groups.ForceSendFields, "MessageModerationLevel")
+		hasUpdates = true
+	}
+	if cmd.Flags().Changed("spam-moderation-level") {
+		groups.SpamModerationLevel = spamModerationLevel
+		groups.ForceSendFields = append(groups.ForceSendFields, "SpamModerationLevel")
+		hasUpdates = true
+	}
+
+	// Email settings
+	if cmd.Flags().Changed("reply-to") {
+		groups.ReplyTo = replyTo
+		groups.ForceSendFields = append(groups.ForceSendFields, "ReplyTo")
+		hasUpdates = true
+	}
+	if cmd.Flags().Changed("custom-reply-to") {
+		groups.CustomReplyTo = customReplyTo
+		groups.ForceSendFields = append(groups.ForceSendFields, "CustomReplyTo")
+		hasUpdates = true
+	}
+	if cmd.Flags().Changed("custom-footer-text") {
+		groups.CustomFooterText = customFooterText
+		groups.ForceSendFields = append(groups.ForceSendFields, "CustomFooterText")
+		hasUpdates = true
+	}
+	if cmd.Flags().Changed("include-custom-footer") {
+		groups.IncludeCustomFooter = includeCustomFooter
+		groups.ForceSendFields = append(groups.ForceSendFields, "IncludeCustomFooter")
+		hasUpdates = true
+	}
+	if cmd.Flags().Changed("send-message-deny-notification") {
+		groups.SendMessageDenyNotification = sendMessageDenyNotification
+		groups.ForceSendFields = append(groups.ForceSendFields, "SendMessageDenyNotification")
+		hasUpdates = true
+	}
+	if cmd.Flags().Changed("include-in-global-address-list") {
+		groups.IncludeInGlobalAddressList = includeInGlobalAddressList
+		groups.ForceSendFields = append(groups.ForceSendFields, "IncludeInGlobalAddressList")
+		hasUpdates = true
+	}
+
+	// Archive settings
+	if cmd.Flags().Changed("archive-only") {
+		groups.ArchiveOnly = archiveOnly
+		groups.ForceSendFields = append(groups.ForceSendFields, "ArchiveOnly")
+		hasUpdates = true
+	}
+	if cmd.Flags().Changed("show-in-group-directory") {
+		groups.ShowInGroupDirectory = showInGroupDirectory
+		groups.ForceSendFields = append(groups.ForceSendFields, "ShowInGroupDirectory")
+		hasUpdates = true
+	}
+
+	// Member management settings
+	if cmd.Flags().Changed("who-can-leave-group") {
+		groups.WhoCanLeaveGroup = whoCanLeaveGroup
+		groups.ForceSendFields = append(groups.ForceSendFields, "WhoCanLeaveGroup")
+		hasUpdates = true
+	}
+	if cmd.Flags().Changed("who-can-add") {
+		groups.WhoCanAdd = whoCanAdd
+		groups.ForceSendFields = append(groups.ForceSendFields, "WhoCanAdd")
+		hasUpdates = true
+	}
+	if cmd.Flags().Changed("who-can-invite") {
+		groups.WhoCanInvite = whoCanInvite
+		groups.ForceSendFields = append(groups.ForceSendFields, "WhoCanInvite")
+		hasUpdates = true
+	}
+	if cmd.Flags().Changed("who-can-approve-members") {
+		groups.WhoCanApproveMembers = whoCanApproveMembers
+		groups.ForceSendFields = append(groups.ForceSendFields, "WhoCanApproveMembers")
+		hasUpdates = true
+	}
+	if cmd.Flags().Changed("allow-google-communication") {
+		groups.AllowGoogleCommunication = allowGoogleCommunication
+		groups.ForceSendFields = append(groups.ForceSendFields, "AllowGoogleCommunication")
+		hasUpdates = true
+	}
+	if cmd.Flags().Changed("members-can-post-as-the-group") {
+		groups.MembersCanPostAsTheGroup = membersCanPostAsTheGroup
+		groups.ForceSendFields = append(groups.ForceSendFields, "MembersCanPostAsTheGroup")
+		hasUpdates = true
+	}
+
+	// Moderation settings
+	if cmd.Flags().Changed("who-can-contact-owner") {
+		groups.WhoCanContactOwner = whoCanContactOwner
+		groups.ForceSendFields = append(groups.ForceSendFields, "WhoCanContactOwner")
+		hasUpdates = true
+	}
+	if cmd.Flags().Changed("who-can-moderate-members") {
+		groups.WhoCanModerateMembers = whoCanModerateMembers
+		groups.ForceSendFields = append(groups.ForceSendFields, "WhoCanModerateMembers")
+		hasUpdates = true
+	}
+	if cmd.Flags().Changed("who-can-moderate-content") {
+		groups.WhoCanModerateContent = whoCanModerateContent
+		groups.ForceSendFields = append(groups.ForceSendFields, "WhoCanModerateContent")
+		hasUpdates = true
+	}
+	if cmd.Flags().Changed("who-can-ban-users") {
+		groups.WhoCanBanUsers = whoCanBanUsers
+		groups.ForceSendFields = append(groups.ForceSendFields, "WhoCanBanUsers")
+		hasUpdates = true
+	}
+
+	if !hasUpdates {
+		fmt.Fprintf(os.Stderr, "Error: No settings specified to update. Use --help to see available flags.\n")
+		return fmt.Errorf("no settings specified")
+	}
+
+	// Update the group settings
+	result, err := client.Groups.Update(groupEmail, groups).Do()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error updating group settings for %s: %v\n", groupEmail, err)
+		return err
+	}
+
+	fmt.Printf("Successfully updated settings for group: %s\n", result.Email)
+
+	// Display updated settings
+	fmt.Println("\nUpdated settings:")
+	for _, field := range groups.ForceSendFields {
+		fmt.Printf("  %s\n", field)
+	}
+
+	return nil
+}

--- a/cmd/group-settings.go
+++ b/cmd/group-settings.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// groupSettingsCmd represents the group-settings command
+var groupSettingsCmd = &cobra.Command{
+	Use:   "group-settings",
+	Short: "Manage group settings",
+	Long: `Manage group settings in your Google Workspace domain.
+
+Group settings control various aspects of how a group operates, including:
+- Who can join and view the group
+- Who can post messages
+- Message moderation settings
+- Email delivery preferences
+- Group archiving settings
+- Custom footer text
+
+Available Commands:
+  list    - View group settings
+  update  - Update group settings
+
+Use "gac group-settings [command] --help" for more information about a command.
+`,
+}
+
+func init() {
+	rootCmd.AddCommand(groupSettingsCmd)
+}

--- a/cmd/group-settings_test.go
+++ b/cmd/group-settings_test.go
@@ -1,0 +1,143 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestGroupSettingsCommandExists(t *testing.T) {
+	if groupSettingsCmd == nil {
+		t.Fatal("Group-settings command should not be nil")
+	}
+
+	if groupSettingsCmd.Use != "group-settings" {
+		t.Errorf("Group-settings command Use = %q, want %q", groupSettingsCmd.Use, "group-settings")
+	}
+
+	if groupSettingsCmd.Short == "" {
+		t.Error("Group-settings command should have a short description")
+	}
+}
+
+func TestGroupSettingsSubcommands(t *testing.T) {
+	expectedCommands := []string{"list", "update"}
+
+	commands := groupSettingsCmd.Commands()
+	commandMap := make(map[string]bool)
+
+	for _, cmd := range commands {
+		// cmd.Use might be "list [group-email]" so extract just the first word
+		use := cmd.Name()
+		commandMap[use] = true
+	}
+
+	for _, cmdName := range expectedCommands {
+		if !commandMap[cmdName] {
+			t.Errorf("Group-settings command missing subcommand: %s", cmdName)
+		}
+	}
+}
+
+func TestGroupSettingsListCommandHasFlags(t *testing.T) {
+	if groupSettingsListCmd == nil {
+		t.Fatal("Group-settings list command should not be nil")
+	}
+
+	// Check for --format flag
+	formatFlag := groupSettingsListCmd.Flags().Lookup("format")
+	if formatFlag == nil {
+		t.Error("Group-settings list command should have --format flag")
+	}
+}
+
+func TestGroupSettingsUpdateCommandHasFlags(t *testing.T) {
+	if groupSettingsUpdateCmd == nil {
+		t.Fatal("Group-settings update command should not be nil")
+	}
+
+	expectedFlags := []string{
+		"who-can-join",
+		"who-can-view-group",
+		"who-can-view-membership",
+		"who-can-post-message",
+		"allow-external-members",
+		"allow-web-posting",
+		"archive-only",
+		"message-moderation-level",
+		"spam-moderation-level",
+		"reply-to",
+		"custom-reply-to",
+		"custom-footer-text",
+		"include-custom-footer",
+		"send-message-deny-notification",
+		"include-in-global-address-list",
+		"show-in-group-directory",
+		"who-can-leave-group",
+		"who-can-add",
+		"who-can-invite",
+		"who-can-approve-members",
+		"allow-google-communication",
+		"members-can-post-as-the-group",
+		"who-can-contact-owner",
+		"who-can-moderate-members",
+		"who-can-moderate-content",
+		"who-can-ban-users",
+	}
+
+	for _, flagName := range expectedFlags {
+		flag := groupSettingsUpdateCmd.Flags().Lookup(flagName)
+		if flag == nil {
+			t.Errorf("Group-settings update command should have --%s flag", flagName)
+		}
+	}
+}
+
+func TestGroupSettingsCommandIsRegistered(t *testing.T) {
+	// Check if group-settings command is registered with root command
+	found := false
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Name() == "group-settings" {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Error("Group-settings command should be registered with root command")
+	}
+}
+
+func TestGroupSettingsListCommandStructure(t *testing.T) {
+	if groupSettingsListCmd.Use != "list [group-email]" {
+		t.Errorf("Group-settings list command Use = %q, want %q", groupSettingsListCmd.Use, "list [group-email]")
+	}
+
+	if groupSettingsListCmd.Short == "" {
+		t.Error("Group-settings list command should have a short description")
+	}
+
+	if groupSettingsListCmd.Long == "" {
+		t.Error("Group-settings list command should have a long description")
+	}
+
+	if groupSettingsListCmd.RunE == nil {
+		t.Error("Group-settings list command should have a RunE function")
+	}
+}
+
+func TestGroupSettingsUpdateCommandStructure(t *testing.T) {
+	if groupSettingsUpdateCmd.Use != "update [group-email]" {
+		t.Errorf("Group-settings update command Use = %q, want %q", groupSettingsUpdateCmd.Use, "update [group-email]")
+	}
+
+	if groupSettingsUpdateCmd.Short == "" {
+		t.Error("Group-settings update command should have a short description")
+	}
+
+	if groupSettingsUpdateCmd.Long == "" {
+		t.Error("Group-settings update command should have a long description")
+	}
+
+	if groupSettingsUpdateCmd.RunE == nil {
+		t.Error("Group-settings update command should have a RunE function")
+	}
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -666,6 +666,127 @@ export BUILDING_ID=main-bldg
 - Regularly audit and remove unused resources
 - Document resource policies (e.g., booking limits, approval requirements)
 
+## 11. Group Settings Management
+
+Manage Google Workspace group settings including access control, posting permissions, moderation, and email preferences.
+
+**File**: [`group-settings-management.sh`](group-settings-management.sh)
+
+**What it demonstrates**:
+- Viewing group settings in table and JSON formats
+- Configuring access control (who can join/view)
+- Setting posting permissions
+- Enabling message moderation
+- Adding custom email footers
+- Managing reply-to and archive settings
+
+**Key commands**:
+```bash
+# View group settings
+gac group-settings list team@example.com
+
+# View settings as JSON
+gac group-settings list team@example.com --format json
+
+# Allow anyone in domain to join
+gac group-settings update team@example.com \
+  --who-can-join ALL_IN_DOMAIN_CAN_JOIN
+
+# Configure posting permissions
+gac group-settings update engineering@example.com \
+  --who-can-post-message ALL_MEMBERS_CAN_POST \
+  --allow-web-posting true
+
+# Enable moderation for announcements
+gac group-settings update announcements@example.com \
+  --message-moderation-level MODERATE_ALL_MESSAGES \
+  --who-can-moderate-content ALL_MANAGERS_CAN_POST
+
+# Add custom footer
+gac group-settings update support@example.com \
+  --custom-footer-text "For help, contact support@example.com" \
+  --include-custom-footer true
+
+# Make group read-only archive
+gac group-settings update archive@example.com \
+  --archive-only true
+```
+
+**Usage**:
+```bash
+# Optionally set group emails
+export GROUP_EMAIL=team@example.com
+export ANNOUNCEMENTS_GROUP=announcements@example.com
+export SUPPORT_GROUP=support@example.com
+
+./examples/group-settings-management.sh
+```
+
+**Common Configuration Scenarios**:
+
+1. **Team Collaboration Group**:
+   ```bash
+   gac group-settings update team@example.com \
+     --who-can-join ALL_IN_DOMAIN_CAN_JOIN \
+     --who-can-post-message ALL_MEMBERS_CAN_POST \
+     --allow-web-posting true \
+     --reply-to REPLY_TO_SENDER
+   ```
+
+2. **Moderated Announcements**:
+   ```bash
+   gac group-settings update announcements@example.com \
+     --who-can-post-message ALL_MANAGERS_CAN_POST \
+     --message-moderation-level MODERATE_ALL_MESSAGES \
+     --who-can-view-group ALL_IN_DOMAIN_CAN_VIEW \
+     --allow-external-members false
+   ```
+
+3. **External Partner Group**:
+   ```bash
+   gac group-settings update partners@example.com \
+     --allow-external-members true \
+     --who-can-join INVITED_CAN_JOIN \
+     --who-can-post-message ALL_MEMBERS_CAN_POST \
+     --message-moderation-level MODERATE_NON_MEMBERS
+   ```
+
+4. **Read-Only Archive**:
+   ```bash
+   gac group-settings update archive-2024@example.com \
+     --archive-only true \
+     --who-can-view-group ALL_IN_DOMAIN_CAN_VIEW \
+     --who-can-post-message NONE_CAN_POST
+   ```
+
+**Available Settings**:
+
+- **Access Control**: `who-can-join`, `who-can-view-group`, `who-can-view-membership`, `allow-external-members`
+- **Posting**: `who-can-post-message`, `allow-web-posting`, `message-moderation-level`, `spam-moderation-level`
+- **Email**: `reply-to`, `custom-reply-to`, `custom-footer-text`, `include-custom-footer`, `include-in-global-address-list`
+- **Archive**: `archive-only`, `show-in-group-directory`
+- **Members**: `who-can-leave-group`, `who-can-add`, `who-can-invite`, `who-can-approve-members`, `members-can-post-as-the-group`
+- **Moderation**: `who-can-contact-owner`, `who-can-moderate-members`, `who-can-moderate-content`, `who-can-ban-users`
+
+**Key Points**:
+- Only update settings you want to change; others remain unchanged
+- Settings use specific values (e.g., `ALL_IN_DOMAIN_CAN_JOIN`, `ALL_MEMBERS_CAN_POST`)
+- Custom footers can include up to 1,000 characters
+- Archive-only groups reject new messages
+- Moderation levels: `MODERATE_ALL_MESSAGES`, `MODERATE_NON_MEMBERS`, `MODERATE_NEW_MEMBERS`, `MODERATE_NONE`
+
+**Best Practices**:
+- Document group purposes and settings in group descriptions
+- Use moderation for announcement-only groups
+- Restrict external members for sensitive groups
+- Add custom footers for support/compliance information
+- Set appropriate join permissions based on group sensitivity
+- Use `archive-only` for historical groups instead of deleting
+- Test settings with a pilot group before applying to all groups
+- Review group settings regularly for security compliance
+- Use reply-to settings to control conversation flow
+- Enable spam moderation for public-facing groups
+
 ## Best Practices
 
 ### Security

--- a/examples/group-settings-management.sh
+++ b/examples/group-settings-management.sh
@@ -1,0 +1,185 @@
+#!/bin/bash
+#
+# Group Settings Management Example
+#
+# This script demonstrates how to view and manage Google Workspace group settings,
+# including access control, posting permissions, moderation, and email preferences.
+#
+# Usage:
+#   ./group-settings-management.sh
+
+set -euo pipefail
+
+echo "========================================="
+echo "Group Settings Management Example"
+echo "========================================="
+echo ""
+echo "This script demonstrates:"
+echo "  1. Viewing group settings"
+echo "  2. Configuring access control (who can join/view)"
+echo "  3. Setting posting permissions"
+echo "  4. Enabling message moderation"
+echo "  5. Adding custom email footers"
+echo "  6. Managing archive settings"
+echo ""
+
+read -p "Press ENTER to start the demo (or Ctrl+C to cancel)..."
+echo ""
+
+# Configuration - Update these with your actual values
+GROUP_EMAIL="${GROUP_EMAIL:-team@example.com}"
+ANNOUNCEMENTS_GROUP="${ANNOUNCEMENTS_GROUP:-announcements@example.com}"
+SUPPORT_GROUP="${SUPPORT_GROUP:-support@example.com}"
+
+echo "Demo Configuration:"
+echo "  Team Group: $GROUP_EMAIL"
+echo "  Announcements Group: $ANNOUNCEMENTS_GROUP"
+echo "  Support Group: $SUPPORT_GROUP"
+echo ""
+
+read -p "Press ENTER to continue..."
+echo ""
+
+# Step 1: View current group settings
+echo "[1/7] Viewing current settings for $GROUP_EMAIL..."
+echo ""
+gac group-settings list "$GROUP_EMAIL"
+echo ""
+
+read -p "Press ENTER to continue to next step..."
+echo ""
+
+# Step 2: Configure access control
+echo "[2/7] Configuring access control settings..."
+echo ""
+echo "Allowing anyone in domain to join the group..."
+gac group-settings update "$GROUP_EMAIL" \
+  --who-can-join ALL_IN_DOMAIN_CAN_JOIN \
+  --allow-external-members false
+echo ""
+echo "✓ Access control updated"
+echo ""
+
+read -p "Press ENTER to continue to next step..."
+echo ""
+
+# Step 3: Configure posting permissions
+echo "[3/7] Configuring posting permissions..."
+echo ""
+echo "Allowing all members to post messages..."
+gac group-settings update "$GROUP_EMAIL" \
+  --who-can-post-message ALL_MEMBERS_CAN_POST \
+  --allow-web-posting true
+echo ""
+echo "✓ Posting permissions updated"
+echo ""
+
+read -p "Press ENTER to continue to next step..."
+echo ""
+
+# Step 4: Set up moderated announcements group
+echo "[4/7] Setting up moderated announcements group..."
+echo ""
+echo "Configuring $ANNOUNCEMENTS_GROUP for moderated announcements..."
+gac group-settings update "$ANNOUNCEMENTS_GROUP" \
+  --who-can-post-message ALL_MANAGERS_CAN_POST \
+  --message-moderation-level MODERATE_ALL_MESSAGES \
+  --who-can-view-group ALL_IN_DOMAIN_CAN_VIEW
+echo ""
+echo "✓ Moderated announcements group configured"
+echo ""
+
+read -p "Press ENTER to continue to next step..."
+echo ""
+
+# Step 5: Add custom footer for support group
+echo "[5/7] Adding custom footer to support group..."
+echo ""
+echo "Adding custom footer to $SUPPORT_GROUP..."
+gac group-settings update "$SUPPORT_GROUP" \
+  --custom-footer-text "For urgent issues, call 1-800-SUPPORT or visit https://support.example.com" \
+  --include-custom-footer true
+echo ""
+echo "✓ Custom footer added"
+echo ""
+
+read -p "Press ENTER to continue to next step..."
+echo ""
+
+# Step 6: Configure reply-to settings
+echo "[6/7] Configuring reply-to settings..."
+echo ""
+echo "Setting reply-to behavior for $GROUP_EMAIL..."
+gac group-settings update "$GROUP_EMAIL" \
+  --reply-to REPLY_TO_SENDER
+echo ""
+echo "✓ Reply-to settings updated"
+echo ""
+
+read -p "Press ENTER to continue to next step..."
+echo ""
+
+# Step 7: View updated settings
+echo "[7/7] Viewing updated settings..."
+echo ""
+echo "Viewing settings in JSON format for $GROUP_EMAIL:"
+echo ""
+gac group-settings list "$GROUP_EMAIL" --format json
+echo ""
+
+echo "========================================="
+echo "Demo Complete!"
+echo "========================================="
+echo ""
+echo "Summary of what we demonstrated:"
+echo ""
+echo "✓ Viewed group settings in table and JSON formats"
+echo "✓ Configured access control (who can join/view)"
+echo "✓ Set posting permissions (who can post)"
+echo "✓ Created a moderated announcements group"
+echo "✓ Added custom email footer for support group"
+echo "✓ Configured reply-to behavior"
+echo ""
+echo "Additional settings you can configure:"
+echo ""
+echo "  Access Control:"
+echo "    --who-can-join                  (CAN_REQUEST_TO_JOIN, ALL_IN_DOMAIN_CAN_JOIN, etc.)"
+echo "    --who-can-view-group            (ANYONE_CAN_VIEW, ALL_IN_DOMAIN_CAN_VIEW, etc.)"
+echo "    --who-can-view-membership       (who can see member list)"
+echo "    --allow-external-members        (true/false)"
+echo ""
+echo "  Posting Permissions:"
+echo "    --who-can-post-message          (NONE_CAN_POST, ALL_MEMBERS_CAN_POST, etc.)"
+echo "    --allow-web-posting             (true/false)"
+echo "    --message-moderation-level      (MODERATE_ALL_MESSAGES, MODERATE_NONE, etc.)"
+echo "    --spam-moderation-level         (spam filter settings)"
+echo ""
+echo "  Email Settings:"
+echo "    --reply-to                      (REPLY_TO_SENDER, REPLY_TO_LIST, etc.)"
+echo "    --custom-reply-to               (custom email address)"
+echo "    --custom-footer-text            (custom footer message)"
+echo "    --include-custom-footer         (true/false)"
+echo "    --include-in-global-address-list (true/false)"
+echo ""
+echo "  Archive Settings:"
+echo "    --archive-only                  (true/false - makes group read-only)"
+echo "    --show-in-group-directory       (true/false)"
+echo ""
+echo "  Member Management:"
+echo "    --who-can-leave-group           (who can leave)"
+echo "    --who-can-add                   (who can add members)"
+echo "    --who-can-invite                (who can invite)"
+echo "    --who-can-approve-members       (who can approve join requests)"
+echo "    --members-can-post-as-the-group (true/false)"
+echo ""
+echo "  Moderation:"
+echo "    --who-can-contact-owner         (who can contact group owners)"
+echo "    --who-can-moderate-members      (who can moderate members)"
+echo "    --who-can-moderate-content      (who can moderate posts)"
+echo "    --who-can-ban-users             (who can ban users)"
+echo ""
+echo "For more information, run:"
+echo "  gac group-settings --help"
+echo "  gac group-settings list --help"
+echo "  gac group-settings update --help"
+echo ""

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,41 @@
+# Git Hooks
+
+This directory contains Git hooks to help maintain code quality.
+
+## Pre-commit Hook
+
+The pre-commit hook runs the following checks before each commit:
+
+1. **go fmt** - Format all Go code
+2. **go vet** - Run static analysis
+3. **golangci-lint** - Run comprehensive linting
+4. **go mod tidy** - Ensure module dependencies are clean
+5. **go build** - Verify the code compiles
+
+## Installation
+
+To install the pre-commit hook, run:
+
+```bash
+cp hooks/pre-commit .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit
+```
+
+Or use this one-liner:
+
+```bash
+ln -sf ../../hooks/pre-commit .git/hooks/pre-commit
+```
+
+## Requirements
+
+- Go 1.25 or later
+- golangci-lint installed (`brew install golangci-lint` or see https://golangci-lint.run/usage/install/)
+
+## Bypassing the Hook
+
+If you need to bypass the hook in an emergency (not recommended):
+
+```bash
+git commit --no-verify
+```

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Pre-commit hook for gac project
+
+set -e
+
+echo "Running pre-commit checks..."
+
+# Format code
+echo "→ Running go fmt..."
+go fmt ./...
+
+# Run go vet
+echo "→ Running go vet..."
+go vet ./...
+
+# Run linter
+echo "→ Running golangci-lint..."
+golangci-lint run ./...
+
+# Run go mod tidy
+echo "→ Running go mod tidy..."
+go mod tidy
+
+# Build to ensure no compilation errors
+echo "→ Building..."
+go build -o /tmp/gac-test
+rm -f /tmp/gac-test
+
+echo "✓ All pre-commit checks passed!"


### PR DESCRIPTION
Implements comprehensive group settings management functionality using the Google Workspace Groups Settings API.

Commands added:
- gac group-settings list: View group settings in table or JSON format
- gac group-settings update: Update group settings with 26+ configurable options

Key features:
- Access control (who-can-join, who-can-view-group, allow-external-members)
- Posting permissions (who-can-post-message, message-moderation-level)
- Email settings (custom-footer-text, reply-to, custom-reply-to)
- Archive settings (archive-only, show-in-group-directory)
- Member management (who-can-add, who-can-invite, who-can-approve-members)
- Moderation controls (who-can-moderate-content, who-can-ban-users)

Implementation details:
- Added groupssettings.AppsGroupsSettingsScope OAuth scope
- Created newGroupsSettingsClient() function in client.go
- Comprehensive test suite with 7 tests (all passing)
- Supports partial updates using ForceSendFields
- Email validation for group and custom-reply-to addresses

Documentation:
- README.md: Added usage examples and command reference
- examples/README.md: Added Section 11 with detailed scenarios
- examples/group-settings-management.sh: Interactive demo script
- TODO.md: Marked feature complete (5/6 features done)

Files created:
- cmd/group-settings.go
- cmd/group-settings-list.go
- cmd/group-settings-update.go
- cmd/group-settings_test.go
- examples/group-settings-management.sh

Common use cases:
- Restricting group access to internal members
- Setting up moderated announcement groups
- Managing external partner collaboration
- Creating read-only archive groups
- Adding custom footers for compliance