### PR TITLE
chore: update go.mod after go mod tidy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,10 @@ require (
 	google.golang.org/protobuf v1.36.9 // indirect
 )
 
-require github.com/google/uuid v1.6.0
+require (
+	github.com/google/uuid v1.6.0
+	github.com/rs/zerolog v1.34.0
+)
 
 require (
 	cloud.google.com/go/auth v0.16.5 // indirect
@@ -39,7 +42,6 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
-	github.com/rs/zerolog v1.34.0 // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0 // indirect


### PR DESCRIPTION
Move zerolog from indirect to direct dependency since it's now used directly by cmd/logger.go