### PR TITLE
fix: replace deprecated reflect.Ptr with reflect.Pointer

### DIFF
--- a/cmd/output.go
+++ b/cmd/output.go
@@ -161,7 +161,7 @@ func formatPlain(w io.Writer, data interface{}) error {
 	v := reflect.ValueOf(data)
 
 	// Handle pointer
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
 
@@ -184,7 +184,7 @@ func formatPlainItem(w io.Writer, item interface{}) error {
 	v := reflect.ValueOf(item)
 
 	// Handle pointer
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		if v.IsNil() {
 			return nil
 		}
@@ -249,7 +249,7 @@ func convertToRows(data interface{}, headers []string) ([][]string, error) {
 	v := reflect.ValueOf(data)
 
 	// Handle pointer
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
 
@@ -280,7 +280,7 @@ func convertItemToRow(item interface{}, headers []string) ([]string, error) {
 	v := reflect.ValueOf(item)
 
 	// Handle pointer
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		if v.IsNil() {
 			return make([]string, len(headers)), nil
 		}


### PR DESCRIPTION
## Summary
- `reflect.Ptr` is a deprecated alias for `reflect.Pointer` since Go 1.18
- New golangci-lint v2.12.1 (pulled as `latest`) flags it via `govet/inline`
- Fixes lint failures on Renovate PRs #61 and #62

## Test plan
- [x] `make check` passes locally (lint, tests, security scan all green)
- [x] CI passes on this PR
- [ ] Renovate PRs #61 and #62 rebase and pass after merge