### PR TITLE
fix: pin trivy-action to SHA instead of @master

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -130,7 +130,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'


### PR DESCRIPTION
## Summary

- `aquasecurity/trivy-action@master` is a mutable branch ref — Renovate can't determine the current version or check for updates, causing the dependency dashboard error
- Pinned to commit SHA `ed142fd0673e97e23eac54620cfb913e5ce36c25` (tag `v0.36.0`, latest stable release)
- Renovate's existing `github-actions` group rule will now track and update this action going forward

## Test plan

- [ ] `security-trivy` CI job passes on this PR
- [ ] Renovate dependency dashboard error clears after merge