### PR TITLE
chore: improve Renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,7 +10,6 @@
   "timezone": "America/New_York",
   "labels": ["dependencies"],
   "assignees": ["acockrell"],
-  "deleteBranchAfterMerge": true,
   "vulnerabilityAlerts": {
     "labels": ["security", "dependencies"],
     "assignees": ["acockrell"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,13 @@
   "timezone": "America/New_York",
   "labels": ["dependencies"],
   "assignees": ["acockrell"],
+  "deleteBranchAfterMerge": true,
+  "vulnerabilityAlerts": {
+    "labels": ["security", "dependencies"],
+    "assignees": ["acockrell"],
+    "schedule": ["at any time"],
+    "automerge": true
+  },
   "packageRules": [
     {
       "description": "Group all Go dependencies (non-major)",
@@ -18,9 +25,18 @@
       "groupName": "Go dependencies"
     },
     {
-      "description": "Group all GitHub Actions",
+      "description": "Group all GitHub Actions and pin to digest SHAs",
       "matchManagers": ["github-actions"],
-      "groupName": "GitHub Actions"
+      "groupName": "GitHub Actions",
+      "pinDigests": true
+    },
+    {
+      "description": "Automerge GitHub Actions minor/patch updates",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash"
     },
     {
       "description": "Automerge patch updates that pass checks",
@@ -35,20 +51,10 @@
       "groupName": "Major updates",
       "schedule": ["before 6am on the first day of the month"],
       "automerge": false
-    },
-    {
-      "description": "Priority for security vulnerabilities",
-      "matchDatasources": ["go"],
-      "vulnerabilityAlerts": {
-        "labels": ["security", "dependencies"],
-        "assignees": ["acockrell"],
-        "schedule": ["at any time"]
-      }
     }
   ],
   "prConcurrentLimit": 5,
   "prHourlyLimit": 2,
   "semanticCommits": "enabled",
-  "commitMessagePrefix": "chore(deps):",
   "rebaseWhen": "behind-base-branch"
 }


### PR DESCRIPTION
## Summary

- **Pin GitHub Actions to digest SHAs** (`pinDigests: true`) — all actions now get SHA-pinned automatically by Renovate, matching what was manually done for `trivy-action` in #65. Prevents supply-chain attacks via mutable version tags.
- **Fix `vulnerabilityAlerts`** — moved from inside a `matchDatasources: ["go"]` package rule (Go-only) to top-level, so GitHub Actions vulns also get priority handling. Added `automerge: true` so security patches merge without manual review.
- **Add `deleteBranchAfterMerge: true`** — stale `renovate/go-dependencies` and `renovate/github-actions` branches will be cleaned up automatically post-merge.
- **Automerge GitHub Actions minor/patch** — interface-stable bumps no longer need manual approval.
- **Remove redundant `commitMessagePrefix`** — `semanticCommits: "enabled"` already generates `chore(deps):` prefixes; the explicit override was a no-op.

## Test plan

- [ ] Validate JSON: `jq . .github/renovate.json` exits 0
- [ ] Check Renovate Dependency Dashboard issue after merge — confirm no config error warnings
- [ ] After next Renovate run: confirm Actions PRs show SHA pins (e.g. `actions/checkout@abc123 # v6.x.x`)
- [ ] Confirm merged Renovate branches are deleted automatically