### PR TITLE
chore: update Renovate timezone to America/Vancouver

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,7 @@
     "group:allNonMajor"
   ],
   "schedule": ["before 6am on Monday"],
-  "timezone": "America/New_York",
+  "timezone": "America/Vancouver",
   "labels": ["dependencies"],
   "assignees": ["acockrell"],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Summary

- Updates Renovate timezone from `America/New_York` to `America/Vancouver`

Renovate will now run before 6am Pacific time on Mondays instead of Eastern time.