### PR TITLE
chore: add path filters to workflows to skip unnecessary runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - main
+    paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Makefile'
+      - '.github/workflows/build.yml'
 
 # Cancel in-progress runs when a new commit is pushed
 concurrency:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -3,6 +3,13 @@ name: PR Checks
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Makefile'
+      - 'Dockerfile'
+      - '.github/workflows/pr-checks.yml'
 
 # Cancel in-progress runs when a new commit is pushed
 concurrency:


### PR DESCRIPTION
## Summary

Adds `paths` filters to `pr-checks.yml` and `build.yml` so Go checks only run when relevant files change. Renovate config updates, docs, and other non-code changes no longer trigger the full CI suite.

### `pr-checks.yml` triggers on changes to:
- `**/*.go`
- `go.mod` / `go.sum`
- `Makefile`
- `Dockerfile` (Trivy scans the filesystem)
- `.github/workflows/pr-checks.yml` (so CI validates itself)

### `build.yml` triggers on changes to:
- `**/*.go`
- `go.mod` / `go.sum`
- `Makefile`
- `.github/workflows/build.yml`

`release.yml` is tag-triggered and unchanged — always appropriate to run on release.

## Note
If required status checks are added to branch protection in future, skipped workflows count as "not run" rather than "passed" and may block merges. Not an issue today since branch protection has no required checks configured.