### PR TITLE
chore: enable Renovate platformAutomerge with safety guards

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,33 +8,35 @@
   ],
   "schedule": ["before 6am on Monday"],
   "timezone": "America/Vancouver",
+  "minimumReleaseAge": "3 days",
   "labels": ["dependencies"],
   "assignees": ["acockrell"],
   "vulnerabilityAlerts": {
     "labels": ["security", "dependencies"],
     "assignees": ["acockrell"],
     "schedule": ["at any time"],
-    "automerge": true
+    "automerge": true,
+    "platformAutomerge": true
   },
   "packageRules": [
     {
-      "description": "Group all Go dependencies (non-major)",
+      "description": "Group all Go dependencies (non-major), automerge minor/patch/digest",
       "matchDatasources": ["go"],
       "matchUpdateTypes": ["minor", "patch", "digest"],
-      "groupName": "Go dependencies"
-    },
-    {
-      "description": "Group all GitHub Actions and pin to digest SHAs",
-      "matchManagers": ["github-actions"],
-      "groupName": "GitHub Actions",
-      "pinDigests": true
-    },
-    {
-      "description": "Automerge GitHub Actions minor/patch updates",
-      "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "Go dependencies",
       "automerge": true,
       "automergeType": "pr",
+      "platformAutomerge": true
+    },
+    {
+      "description": "Group all GitHub Actions, pin to digest SHAs, automerge all non-major",
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions",
+      "pinDigests": true,
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true,
       "automergeStrategy": "squash"
     },
     {
@@ -42,6 +44,7 @@
       "matchUpdateTypes": ["patch"],
       "automerge": true,
       "automergeType": "pr",
+      "platformAutomerge": true,
       "automergeStrategy": "squash"
     },
     {


### PR DESCRIPTION
## Summary

- Add `platformAutomerge: true` to all automerge rules so Renovate uses GitHub's native auto-merge API (previously automerge was configured but never firing)
- Add `minimumReleaseAge: "3 days"` globally — supply chain safety net that prevents merging packages published less than 3 days ago
- Extend Go dependencies rule with `automerge: true` (was grouping-only, blocking minor/patch/digest updates like PR #72)
- Collapse GitHub Actions into one rule covering `minor`, `patch`, and `digest` (SHA rotation updates like PR #71 now covered)

## GitHub settings (applied separately, outside this PR)

- Repo-level `allow_auto_merge` enabled via `gh api` — required for GitHub native auto-merge API
- Branch protection on `main` with required status check `All Checks Passed` — needs to be applied manually (see below)

To apply branch protection, run:
```bash
gh api repos/ACLabs-Code/google-admin-client/branches/main/protection \
  --method PUT \
  --input - <<'PROTECTION'
{
  "required_status_checks": {
    "strict": false,
    "checks": [{ "context": "All Checks Passed" }]
  },
  "enforce_admins": false,
  "required_pull_request_reviews": null,
  "restrictions": null,
  "allow_force_pushes": false,
  "allow_deletions": false
}
PROTECTION
```

## Test plan

- [ ] Apply branch protection command above
- [ ] Merge this PR
- [ ] Check the rebase checkbox on PRs #71 and #72 — they should automerge once CI passes
- [ ] Verify: `gh api repos/ACLabs-Code/google-admin-client --jq .allow_auto_merge` returns `true`
- [ ] Verify: `gh api repos/ACLabs-Code/google-admin-client/branches/main/protection --jq .required_status_checks`