### PR TITLE
fix(renovate): ignore aquasecurity/trivy-action to silence lookup failure

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -55,6 +55,7 @@
       "automerge": false
     }
   ],
+  "ignoreDeps": ["aquasecurity/trivy-action"],
   "prConcurrentLimit": 5,
   "prHourlyLimit": 2,
   "semanticCommits": "enabled",


### PR DESCRIPTION
## Summary

- Adds `aquasecurity/trivy-action` to `ignoreDeps` in `renovate.json`

Renovate's `github-tags` datasource consistently returns `no-result` for this action, causing a persistent warning on the Dependency Dashboard. The action is already digest-pinned in the workflow (`v0.36.0@ed142fd067...`) so it won't drift without Renovate management — update it manually when a new version is needed.

## Test plan

- [ ] Merge this PR
- [ ] Trigger Renovate via the Dependency Dashboard checkbox
- [ ] Confirm the lookup failure warning is gone